### PR TITLE
UI: Phase 1 visual polish (CHNC-neutral theme)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import DateRangePicker from '@/components/DateRangePicker';
 import HollywoodMap from '@/components/HollywoodMap';
 import CrimeDashboard from '@/components/CrimeDashboard';
 import LoadingSpinner from '@/components/LoadingSpinner';
+import { ArrowRightCircleIcon } from '@heroicons/react/24/solid';
 
 interface DateRange {
   minDate: string;
@@ -130,9 +131,17 @@ export default function Home() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      {/* Top Meta Bar */}
+      <div className="bg-gradient-to-r from-blue-50 via-emerald-50 to-blue-50 border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 text-xs text-gray-600 flex items-center justify-between">
+          <span>Data source: LA City Open Data (LAPD NIBRS)</span>
+          <a href="https://dev.socrata.com/foundry/data.lacity.org/y8y3-fqfu" target="_blank" rel="noreferrer" className="text-emerald-700 hover:text-emerald-800">View dataset →</a>
+        </div>
+      </div>
+
       {/* Header */}
-      <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+      <header className="bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/60 shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-3xl font-bold text-gray-900">
@@ -190,7 +199,7 @@ export default function Home() {
             <button
               onClick={handleGenerateReport}
               disabled={!selectedDateRange || loading}
-              className="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex items-center px-6 py-3 border border-transparent text-base font-semibold rounded-md shadow-sm text-white bg-emerald-600 hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {loading ? (
                 <>
@@ -198,7 +207,10 @@ export default function Home() {
                   Generating Report...
                 </>
               ) : (
-                'Generate Crime Report'
+                <>
+                  Generate Crime Report
+                  <ArrowRightCircleIcon className="ml-2 h-5 w-5 text-white/90" />
+                </>
               )}
             </button>
           </div>

--- a/src/components/CrimeDataTable.tsx
+++ b/src/components/CrimeDataTable.tsx
@@ -225,9 +225,10 @@ export default function CrimeDataTable({ data }: CrimeDataTableProps) {
       {/* Table */}
       <div className="bg-white border rounded-lg overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
+          <div className="max-h-[60vh] overflow-y-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50 sticky top-0 z-10 shadow">
+                <tr>
                 <th 
                   className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
                   onClick={() => handleSort('date_occ')}
@@ -271,8 +272,8 @@ export default function CrimeDataTable({ data }: CrimeDataTableProps) {
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
               {paginatedData.map((record, index) => (
-                <tr key={record.uniquenibrno} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                <tr key={record.uniquenibrno} className={index % 2 === 0 ? 'bg-white hover:bg-gray-50' : 'bg-gray-50 hover:bg-gray-100'}>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-mono">
                     {format(parseISO(record.date_occ), 'MMM dd, yyyy')}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
@@ -330,6 +331,7 @@ export default function CrimeDataTable({ data }: CrimeDataTableProps) {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
 
         {/* Pagination */}

--- a/src/components/CrimeSummary.tsx
+++ b/src/components/CrimeSummary.tsx
@@ -68,44 +68,38 @@ export default function CrimeSummary({ stats }: CrimeSummaryProps) {
     <div className="space-y-8">
       {/* Key Statistics Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <div className="bg-blue-50 rounded-lg p-6">
+        <div className="rounded-lg p-6 bg-gradient-to-br from-emerald-50 to-blue-50 border border-emerald-100">
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <div className="w-8 h-8 bg-blue-500 rounded-md flex items-center justify-center">
-                <span className="text-white font-bold text-sm">📊</span>
-              </div>
+              <div className="w-8 h-8 bg-emerald-600 rounded-md flex items-center justify-center text-white">📊</div>
             </div>
             <div className="ml-4">
-              <p className="text-sm font-medium text-blue-600">Total Incidents</p>
-              <p className="text-2xl font-bold text-blue-900">{stats.totalCrimes.toLocaleString()}</p>
+              <p className="text-sm font-medium text-emerald-700">Total Incidents</p>
+              <p className="text-3xl font-bold text-gray-900">{stats.totalCrimes.toLocaleString()}</p>
             </div>
           </div>
         </div>
 
-        <div className="bg-red-50 rounded-lg p-6">
+        <div className="rounded-lg p-6 bg-gradient-to-br from-rose-50 to-red-50 border border-rose-100">
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <div className="w-8 h-8 bg-red-500 rounded-md flex items-center justify-center">
-                <span className="text-white font-bold text-sm">🚨</span>
-              </div>
+              <div className="w-8 h-8 bg-rose-600 rounded-md flex items-center justify-center text-white">🚨</div>
             </div>
             <div className="ml-4">
-              <p className="text-sm font-medium text-red-600">Domestic Violence</p>
-              <p className="text-2xl font-bold text-red-900">{stats.specialCrimes.domesticViolence}</p>
+              <p className="text-sm font-medium text-rose-700">Domestic Violence</p>
+              <p className="text-3xl font-bold text-gray-900">{stats.specialCrimes.domesticViolence}</p>
             </div>
           </div>
         </div>
 
-        <div className="bg-green-50 rounded-lg p-6">
+        <div className="rounded-lg p-6 bg-gradient-to-br from-emerald-50 to-green-50 border border-emerald-100">
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <div className="w-8 h-8 bg-green-500 rounded-md flex items-center justify-center">
-                <span className="text-white font-bold text-sm">✅</span>
-              </div>
+              <div className="w-8 h-8 bg-green-600 rounded-md flex items-center justify-center text-white">✅</div>
             </div>
             <div className="ml-4">
-              <p className="text-sm font-medium text-green-600">Cleared Cases</p>
-              <p className="text-2xl font-bold text-green-900">
+              <p className="text-sm font-medium text-green-700">Cleared Cases</p>
+              <p className="text-3xl font-bold text-gray-900">
                 {Object.entries(stats.statuses)
                   .filter(([status]) => status.includes('Cleared'))
                   .reduce((sum, [, count]) => sum + count, 0)}
@@ -114,16 +108,14 @@ export default function CrimeSummary({ stats }: CrimeSummaryProps) {
           </div>
         </div>
 
-        <div className="bg-purple-50 rounded-lg p-6">
+        <div className="rounded-lg p-6 bg-gradient-to-br from-violet-50 to-purple-50 border border-violet-100">
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <div className="w-8 h-8 bg-purple-500 rounded-md flex items-center justify-center">
-                <span className="text-white font-bold text-sm">🏠</span>
-              </div>
+              <div className="w-8 h-8 bg-violet-600 rounded-md flex items-center justify-center text-white">🏠</div>
             </div>
             <div className="ml-4">
-              <p className="text-sm font-medium text-purple-600">Homeless Related</p>
-              <p className="text-2xl font-bold text-purple-900">
+              <p className="text-sm font-medium text-violet-700">Homeless Related</p>
+              <p className="text-3xl font-bold text-gray-900">
                 {stats.specialCrimes.homelessVictim + stats.specialCrimes.homelessSuspect}
               </p>
             </div>
@@ -137,24 +129,25 @@ export default function CrimeSummary({ stats }: CrimeSummaryProps) {
         <div className="bg-white border rounded-lg p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Top Crime Types</h3>
           <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={topCrimeTypes} margin={{ top: 20, right: 30, left: 20, bottom: 60 }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis 
-                dataKey="name" 
+            <BarChart data={topCrimeTypes} margin={{ top: 20, right: 16, left: 8, bottom: 60 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis
+                dataKey="name"
                 angle={-45}
                 textAnchor="end"
                 height={80}
                 fontSize={12}
               />
-              <YAxis />
+              <YAxis tick={{ fontSize: 12 }} tickLine={false} axisLine={{ stroke: '#e5e7eb' }} />
               <Tooltip
+                contentStyle={{ borderRadius: 8, borderColor: '#e5e7eb' }}
                 formatter={(value) => [value, 'Count']}
                 labelFormatter={(label) => {
                   const item = topCrimeTypes.find(d => d.name === label);
                   return item?.fullName || label;
                 }}
               />
-              <Bar dataKey="count" fill="#3b82f6" />
+              <Bar dataKey="count" fill="#059669" />
             </BarChart>
           </ResponsiveContainer>
         </div>
@@ -171,14 +164,14 @@ export default function CrimeSummary({ stats }: CrimeSummaryProps) {
                 labelLine={false}
                 label={({ name, percentage }) => `${name}: ${percentage}%`}
                 outerRadius={80}
-                fill="#8884d8"
+                fill="#10b981"
                 dataKey="value"
               >
                 {crimeAgainstData.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                 ))}
               </Pie>
-              <Tooltip formatter={(value) => [value, 'Count']} />
+              <Tooltip formatter={(value) => [value, 'Count']} contentStyle={{ borderRadius: 8, borderColor: '#e5e7eb' }} />
             </PieChart>
           </ResponsiveContainer>
         </div>
@@ -213,24 +206,25 @@ export default function CrimeSummary({ stats }: CrimeSummaryProps) {
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Daily Crime Trend</h3>
           <ResponsiveContainer width="100%" height={250}>
             <LineChart data={dailyTrendData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis 
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis
                 dataKey="formattedDate"
                 fontSize={12}
               />
-              <YAxis />
-              <Tooltip 
+              <YAxis tick={{ fontSize: 12 }} tickLine={false} axisLine={{ stroke: '#e5e7eb' }} />
+              <Tooltip
                 labelFormatter={(label) => {
                   const item = dailyTrendData.find(d => d.formattedDate === label);
-                  return item ? new Date(item.date).toLocaleDateString('en-US', { 
-                    weekday: 'long', 
-                    year: 'numeric', 
-                    month: 'long', 
-                    day: 'numeric' 
+                  return item ? new Date(item.date).toLocaleDateString('en-US', {
+                    weekday: 'long',
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric'
                   }) : label;
                 }}
+                contentStyle={{ borderRadius: 8, borderColor: '#e5e7eb' }}
               />
-              <Line type="monotone" dataKey="count" stroke="#3b82f6" strokeWidth={2} />
+              <Line type="monotone" dataKey="count" stroke="#059669" strokeWidth={2} dot={false} />
             </LineChart>
           </ResponsiveContainer>
         </div>

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -138,33 +138,33 @@ export default function DateRangePicker({ availableRange, selectedRange, onChang
         </div>
       )}
 
-      {/* Preset Buttons */}
-      <div className="flex flex-wrap gap-2">
+      {/* Preset Buttons as Segmented Control */}
+      <div className="inline-flex rounded-md shadow-sm border border-gray-200 overflow-hidden">
         <button
           type="button"
           onClick={() => setPresetRange(7)}
-          className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         >
           Last 7 days
         </button>
         <button
           type="button"
           onClick={() => setPresetRange(30)}
-          className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500 border-l border-gray-200"
         >
           Last 30 days
         </button>
         <button
           type="button"
           onClick={() => setPresetRange(90)}
-          className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500 border-l border-gray-200"
         >
           Last 90 days
         </button>
         <button
           type="button"
           onClick={() => setPresetRange(365)}
-          className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500 border-l border-gray-200"
         >
           Last year
         </button>


### PR DESCRIPTION
This PR delivers Phase 1 visual polish with a very light CHNC nod while keeping a neutral, civic look.

Highlights
- Header + top meta bar: subtle gradient, dataset link, blur effect
- Controls: segmented date presets; promoted primary action with emerald accent + icon
- Summary: harmonized stat cards with soft gradients and tone-on-tone icons
- Charts: unified palette, lighter grid lines, improved tooltips
- Table: sticky header, internal scroll (max 60vh), row hover states, monospace date

Tech
- No new runtime deps beyond heroicons (already present)
- Types clean, Next build succeeds

Screens
- Designed to look good on desktop and mobile; on mobile the table remains usable with horizontal scroll.

Once merged to main, Vercel should auto-deploy production. If you prefer, we can review the Vercel Preview first, then merge.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author